### PR TITLE
Wrong file name

### DIFF
--- a/dev/docker/docker-compose.yaml
+++ b/dev/docker/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
   postgres:
     build:
       context: ./postgres
-      dockerfile: Dockerfile.postgres
+      dockerfile: Dockerfile
     ports:
       - 5432:5432
     environment:


### PR DESCRIPTION
The docker-compose command can't find the PG dockerfile as it is not named correctly